### PR TITLE
Fix console error in wizard user configuration

### DIFF
--- a/app/scripts/controllers/users/configurations.js
+++ b/app/scripts/controllers/users/configurations.js
@@ -11,7 +11,7 @@ angular.module('nethvoiceWizardUiApp')
   .controller('UsersConfigurationsCtrl', function ($scope, $filter, UserService, DeviceService, ProfileService, UtilService) {
     $scope.users = {};
     $scope.selectedUser = null;
-    $scope.devices = {};
+    $scope.devices = [];
     $scope.allProfiles = [];
     $scope.allGroups = [];
     $scope.maxExtensionReached = false;


### PR DESCRIPTION
On User Configurations section load there is an unexpected type variable error in console
Converting variable from obj to array fixes the error