### PR TITLE
add i18n for physical phone buttons permission

### DIFF
--- a/wizard/app/scripts/i18n/locale-it.json
+++ b/wizard/app/scripts/i18n/locale-it.json
@@ -848,5 +848,6 @@
   "Remember to save the NAT Settings before continue": "Ricorda di salvare le Impostazioni NAT prima di continuare",
   "NAT Settings saved": "Impostazioni NAT salvate",
   "NAT Settings saved with success": "Impostazioni NAT salvate con successo",
+  "Allow to customize physical phone buttons": "Consente la configurazione dei tasti dei telefoni fisici",
   "Remember to save the password before continue": "Ricorda di salvare la password prima di continuare"
 }


### PR DESCRIPTION
It's the translation for the user profile permission to customize physical phone buttons.
![image](https://user-images.githubusercontent.com/1625334/79967367-0490a700-848f-11ea-8842-264b19cd7537.png)
