### PR TITLE
Simplify show secret for custom device

### DIFF
--- a/wizard/app/scripts/i18n/locale-it.json
+++ b/wizard/app/scripts/i18n/locale-it.json
@@ -361,6 +361,7 @@
   "Source": "Sorgente",
   "Sources": "Sorgenti",
   "Show": "Mostra",
+  "Show Secret": "Mostra Password",
   "Hide": "Nascondi",
   "Code": "Codice",
   "Color": "Colore",

--- a/wizard/app/views/configurations.html
+++ b/wizard/app/views/configurations.html
@@ -252,8 +252,7 @@
                               </div>
                             </div>
                             <!-- show secret for custom devices -->
-                            <span ng-if="!device.mac && (device.type === 'physical' || device.type === 'temporaryphysical')">{{"Extension's secret" | translate}}: </span>
-                            <button ng-if="!device.mac && (device.type === 'physical' || device.type === 'temporaryphysical')" popover-animation="true" uib-popover="{{device.secret}}" type="button" class="btn btn-default">{{'Show' | translate}}</button>
+                            <button ng-if="!device.mac && (device.type === 'physical' || device.type === 'temporaryphysical')" popover-animation="true" uib-popover="{{device.secret}}" type="button" class="btn btn-default">{{'Show Secret' | translate}}</button>
                           </div>
                           <div ng-if="!(!device.mac && (device.type === 'physical' || device.type === 'temporaryphysical'))"
                             class="col-lg-5 mnw-180">


### PR DESCRIPTION
The involved service page is "Configurations".
Clicking a user you can see the custom devices and for each of them the button "Show Secret"

Before:
![image](https://user-images.githubusercontent.com/1625334/80000532-8992b500-84bd-11ea-854c-f03ec92e4f99.png)


After:
![image](https://user-images.githubusercontent.com/1625334/80000391-636d1500-84bd-11ea-9c7e-4cc27b1037f4.png)
