### PR TITLE
Fetch MAC addresses from Tancredi

### DIFF
--- a/wizard/app/scripts/macVendors.js
+++ b/wizard/app/scripts/macVendors.js
@@ -2,5 +2,5 @@ var macVendors = ((function () {
   var req = new XMLHttpRequest();
   req.open("GET", "/tancredi/api/v1/macvendors", false);
   req.send();
-  return req.status == 200 && req.responseType == "json" ? req.response : {};
+  return req.status == 200 ? JSON.parse(req.response) : {};
 })());


### PR DESCRIPTION
Tancredi provides an API that returns the same information,
depending on the supported phone models, from an user-configurable
set of MAC-vendors items.

Replace the static map with a dynamically generated one.

Requires: https://github.com/nethesis/nethserver-tancredi/pull/64

nethesis/dev#5839